### PR TITLE
Add libtorch 1.6.0 pre-built for NVIDIA Drive PX2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Pre-built libtorch for ARM32/64 Systems
+
+## NVIDIA Drive PX2
+
+The pre-built package is `./https://github.com/wangkuiyi/pytorch-rpi.zip`.
+
+The steps to build it include:
+
+1. Log in to an NVIDIA Drive PX2 computer.
+1. Upgrade the system from Ubuntu 16.04 to Ubuntu 18.04 for a recent Python.
+1. Install Clang with `sudo apt-get install -y clang`.
+1. Set environment variables:
+   ```bash
+   export USE_CUDA=0
+   export USE_QNNPACK=0
+   export USE_PYTORCH_QNNPACK=0
+   ```
+1. Run `./build_libtorch.sh` to build and pack the zip file.

--- a/libtorch-px2-shared-without-deps-1.6.0.zip.sha256
+++ b/libtorch-px2-shared-without-deps-1.6.0.zip.sha256
@@ -1,0 +1,1 @@
+08ad4f9df98791d3360097b094a38bd33112202f0deee0b6729fba60e9db7e90  libtorch-rpi-shared-without-deps-1.6.0.zip


### PR DESCRIPTION
This change adds the pre-built libtorch ZIP archive for NVIDIA Drive PX2 using git lfs.

A PX2 device has one or two SoC systems, where each SoC contains 4 aarch64 CPU cores and two CUDA GPU cores.  This change uploads the version of libtorch that doesn't have CUDA support.  In a future change, I will try to add the version with CUDA.